### PR TITLE
Relax yamllint checks for .github hierarchy

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,8 @@ rules:
   document-start:
     ignore: |
       Taskfile.yml
+      .github
   line-length:
     ignore: |
       Taskfile.yml
+      .github


### PR DESCRIPTION
Ignore both document-start and line-length checks for GitHub files too because, respectively:

- Not having `---` in GitHub Actions workflows files is pretty common and not needed
- Line too long check can be often tricky in GitHub Actions workflows to resolve and can sometimes make the code harder to read
