### PR TITLE
Add a k3s task

### DIFF
--- a/files/k3s-config.yaml
+++ b/files/k3s-config.yaml
@@ -1,0 +1,3 @@
+---
+disable: metrics-server,traefik
+disable-cloud-controller: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,8 +2,13 @@
 - name: Configure RPI4
   hosts: all
 
+  vars:
+    k3s_version: v1.25.4+k3s1
+
   tasks:
     - name: Update all packages to latest version.
       ansible.builtin.import_tasks: tasks/update_packages.yml
     - name: Ensure local DNS resolver is running.
       ansible.builtin.import_tasks: tasks/dns_resolver.yml
+    - name: Ensure k3s is running.
+      ansible.builtin.import_tasks: tasks/k3s.yml

--- a/tasks/k3s.yml
+++ b/tasks/k3s.yml
@@ -1,0 +1,59 @@
+---
+#
+# Setup k3s.
+#
+# Setup and configure k3s in order to be used as a single node Kubernetes
+# cluster.
+#
+# Installation and manual upgrades follows upstream documentation at:
+#
+# - <https://docs.k3s.io/quick-start>
+# - <https://docs.k3s.io/upgrades/manual>
+#
+
+- name: Check that k3s_version is defined and is of expected format.
+  delegate_to: localhost
+  ansible.builtin.assert:
+    that:
+      - k3s_version | regex_search('v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+')
+    fail_msg: >
+      Unexpected k3s version: {{ k3s_version }}.
+      k3s version should match 'v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+'
+      regular expression.
+    quiet: true
+- name: Populate k3s configuration.
+  become: true
+  ansible.builtin.copy:
+    src: files/k3s-config.yaml
+    dest: /etc/rancher/k3s/config.yaml
+    owner: root
+    group: root
+    directory_mode: '0755'
+    mode: '0644'
+- name: Get k3s version, if installed.
+  become: true
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      {
+        k3s --version |
+        awk '
+          /^k3s version/ {
+            if (match($0, /v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+/)) {
+              print substr($0, RSTART, RLENGTH)
+            }
+          }'
+      } || true # ignore if k3s fails and/or does not exists
+  register: k3s_version_command
+  changed_when: false
+- name: Install/upgate k3s, if needed.
+  become: true
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      curl --fail --location --silent https://get.k3s.io |
+      INSTALL_K3S_VERSION="{{ k3s_version }}" sh -s -
+  changed_when: true
+  when: k3s_version != k3s_version_command.stdout


### PR DESCRIPTION
Add a k3s task in order to configure and install/upgrade k3s.

It first populate k3s's `config.yaml` and then follow upstream installation and manual upgrades notes.
