### PR TITLE
Add run target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,3 +39,12 @@ tasks:
       - task: yamllint
       - task: syntax-check
       - task: ansible-lint
+
+  run:
+    desc: Run Ansible playbooks.
+    summary: |
+      Run Ansible playbooks.
+
+      Run the Ansible playbooks against RPI to configure it.
+    cmds:
+      - ansible-playbook --verbose playbook.yml


### PR DESCRIPTION
Add the `ansible-playbook` incantation in order to apply the Ansible playbooks.

Mostly a reference to avoid typing it.
