### PR TITLE
Update to latest k3s 1.26.x version

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
 
   vars:
-    k3s_version: v1.25.16+k3s4
+    k3s_version: v1.26.12+k3s1
 
   tasks:
     - name: Update all packages to latest version.


### PR DESCRIPTION
Update to k3s 1.26.x in order to get back to currently maintained k3s versions.

There should be no breaking changes for current usage.
