### PR TITLE
Extend github checks to all .github

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -24,4 +24,4 @@ jobs:
         env:
           CONFTEST_POLICIES: git::https://github.com/iamleot/conftest-policies.git//policy/github
         run: |
-          conftest test --all-namespaces --update "${{ env.CONFTEST_POLICIES }}" .github/workflows
+          conftest test --all-namespaces --update "${{ env.CONFTEST_POLICIES }}" .github


### PR DESCRIPTION
Do not limit conftest to check .github/workflows but also check the rest of .github hierarchy. Also some checks against dependabot.yml are done!
