### PR TITLE
Prepare k3s for Cilium

### DIFF
--- a/files/k3s-config.yaml
+++ b/files/k3s-config.yaml
@@ -1,3 +1,5 @@
 ---
+flannel-backend: none
 disable: metrics-server,traefik
 disable-cloud-controller: true
+disable-network-policy: true


### PR DESCRIPTION
Set Flannel backend to none and disable support for NetworkPolicy-ies.

Both required by k3s in order to run Cilium.

Based on <https://docs.cilium.io/en/stable/installation/k8s-install-helm/>.
