### PR TITLE
Ensure that k3s directory exists

### DIFF
--- a/tasks/k3s.yml
+++ b/tasks/k3s.yml
@@ -21,6 +21,14 @@
       k3s version should match 'v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+'
       regular expression.
     quiet: true
+- name: Ensure k3s directory exists.
+  become: true
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
 - name: Populate k3s configuration.
   become: true
   ansible.builtin.copy:


### PR DESCRIPTION
We need `/etc/rancher/k3s` otherwise we could not populate k3s configuration.

Noticed when running the playbook after a `k3s-uninstall.sh`.
