### PR TITLE
Switch back to Flannel

### DIFF
--- a/files/k3s-config.yaml
+++ b/files/k3s-config.yaml
@@ -1,5 +1,3 @@
 ---
-flannel-backend: none
 disable: metrics-server,traefik
 disable-cloud-controller: true
-disable-network-policy: true


### PR DESCRIPTION
Cilium seems too unstable on RPI4. Several pods are experiencing lot of restarts and the cluster is expierencing a lot of `KubeAPIErrorBudgetBurn` alert.
