### PR TITLE
Update to latest k3s 1.28.x version

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -5,7 +5,7 @@
   vars:
     # List of channels with latest versions is available at
     # <https://update.k3s.io/v1-release/channels>.
-    k3s_version: v1.28.9+k3s1
+    k3s_version: v1.28.15+k3s1
 
   tasks:
     - name: Update all packages to latest version.


### PR DESCRIPTION
Update to k3s-1.28.15+k3s1 to catch up with the latest k3s 1.28.x version.
