### PR TITLE
Update to latest k3s 1.29.x version

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -5,7 +5,7 @@
   vars:
     # List of channels with latest versions is available at
     # <https://update.k3s.io/v1-release/channels>.
-    k3s_version: v1.28.15+k3s1
+    k3s_version: v1.29.12+k3s1
 
   tasks:
     - name: Update all packages to latest version.


### PR DESCRIPTION
Kubernetes 1.28.x is no longer supported, update to latest k3s 1.29.x.
