### PR TITLE
Adjust Renovate configuration similar to rpi-flux one

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "labels": ["dependencies"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "schedule": ["* 4 * * 3"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,17 @@
       ],
       "depNameTemplate": "open-policy-agent/conftest",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "TASK_VERSION:\\s+\"(?<currentValue>.*)\""
+      ],
+      "depNameTemplate": "go-task/task",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "labels": ["dependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,19 @@
   "extends": [
     "config:recommended"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "CONFTEST_VERSION:\\s+\"(?<currentValue>.*)\""
+      ],
+      "depNameTemplate": "open-policy-agent/conftest",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "labels": ["dependencies"],
   "schedule": ["* 4 * * 3"]
 }


### PR DESCRIPTION
This PR:

- Automatically add "dependencies" label
- Schedule PRs opening weekly
- Add custom matcher for CONFTEST_VERSION
- Add custom matcher for TASK_VERSION

All these changes are based on the ones that were done in https://github.com/iamleot/rpi-flux where I have started to explore Renovate.
