### PR TITLE
Update to k3s 1.32.2+k3s1

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -5,7 +5,7 @@
   vars:
     # List of channels with latest versions is available at
     # <https://update.k3s.io/v1-release/channels>.
-    k3s_version: v1.31.6+k3s1
+    k3s_version: v1.32.2+k3s1
 
   tasks:
     - name: Update all packages to latest version.


### PR DESCRIPTION
Update to latest k3s 1.32.x version.

Full release note available at:
<https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/>.
