### PR TITLE
Add k3s role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -12,7 +12,4 @@
     - role: network
     - role: dns_resolver
     - role: wireguard
-
-  tasks:
-    - name: Ensure k3s is running.
-      ansible.builtin.import_tasks: tasks/k3s.yml
+    - role: k3s

--- a/roles/k3s/files/k3s-config.yaml
+++ b/roles/k3s/files/k3s-config.yaml
@@ -1,0 +1,3 @@
+---
+disable: metrics-server,traefik
+disable-cloud-controller: true

--- a/roles/k3s/meta/main.yml
+++ b/roles/k3s/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Populate k3s configuration.
   become: true
   ansible.builtin.copy:
-    src: files/k3s-config.yaml
+    src: k3s-config.yaml
     dest: /etc/rancher/k3s/config.yaml
     owner: root
     group: root


### PR DESCRIPTION
Move all `tasks/k3s.yml` to a dedicated k3s role.

We should generalize it more but that's a starting point making everything more reusable.
