### PR TITLE
Autoclean and autoremove packages

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -8,6 +8,14 @@
   ansible.builtin.apt:
     cache_valid_time: 3600
     update_cache: true
+- name: Clean up no longer useful package files
+  become: true
+  ansible.builtin.apt:
+    autoclean: true
+- name: Remove unused dependency packages
+  become: true
+  ansible.builtin.apt:
+    autoremove: true
 - name: Update all packages to latest version.
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Run the equivalent of `apt autoclean` and `apt autoremove` to regularly free up space before every upgrades.

In particular `apt autoremove` is regularly needed because `/boot/firmware` is a dedicated partition and it is easy to no longer have free space after a couple of kernel upgrades.

This should avoid issues similar to what we had in #75.
